### PR TITLE
#168131122 adds endpoints and test for rejecting a session

### DIFF
--- a/server/routes/session-routes.js
+++ b/server/routes/session-routes.js
@@ -124,3 +124,45 @@ router.patch('/:sessionId/accept', function (req, res) {
     }
 });
 
+
+router.patch('/:sessionId/reject', function (req, res) {
+    res.set("Content-type", "application/json");
+    console.log('About to accept a session: <' + JSON.stringify(req.body) + '>');
+
+    var token = req.body.token; // token will be validated once database is ready
+    var mentorId = req.body.mentorId;
+
+    var allMentors = [mentor1, mentor2]; // Using hard-coded values since there is no database
+    
+    var isMentorFound = false;
+    var data = {};
+    allMentors.forEach(
+          (mentor) => {
+                if(mentor.mentorId === mentorId) {
+                      data.sessionId = uuid();
+                      data.mentorId = mentor.mentorId;
+                      data.status = "rejected";
+                      isMentorFound = true;
+                }
+          }
+    );
+    
+    if(global.savedUser.token === req.get('token') && isMentorFound == true) {
+          var specificMentorResponse = {};
+          specificMentorResponse.status = 200;
+          specificMentorResponse.data = data;
+    
+          res.status(200).send(specificMentorResponse);
+    } else {
+          var specificMentorResponse = {};
+          var data = {};
+          data.status = "failed";
+          data.message = "Unable to reject a session";
+          specificMentorResponse.data = data;
+    
+          res.status(401).send(specificMentorResponse);
+    }
+});
+
+
+module.exports = router;

--- a/server/tests/session-routes-test.js
+++ b/server/tests/session-routes-test.js
@@ -67,3 +67,33 @@ describe('Mentor should accept a session', () => {
         });
     });
   });
+
+
+  /*
+ * 3) Tests for rejecting a session:
+ */
+describe('Mentor should reject a session', () => {
+    it('Expect to reject a session', (done) => {
+      chai.request(server)
+        .patch('/api/v1/sessions/' + global.savedUser.sessionId + '/reject')
+        .set('token', global.savedUser.token)
+        .send(mentor)
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+    it('Expect to fail to reject a session', (done) => {
+      chai.request(server)
+        .patch('/api/v1/sessions/' + '12345' + '/reject')
+        .send(mentor)
+        .end((err, res) => {
+          console.log(res.body);
+          
+          expect(res).to.have.status(401);
+          expect(res.body).to.be.an('object');
+          done();
+        });
+    });
+  });


### PR DESCRIPTION
#### What does this PR do?
It adds endpoints and test for rejecting a session
#### Description of Task to be completed?
Title: Developer should be able to set and test API endpoints for rejecting mentor-ship session request

Business/Developer Value: For Developer, It should be possible to set and test API endpoints for the app so that postman covers 60%

Acceptance Criteria
GIVEN A developer
WHEN developer runs a test of API endpoints for rejecting mentor-ship session request
THEN Developer should have a coverage report of 60%

DEV NOTES
Developer should set and test API endpoints

#### Any background context you want to provide?
I added endpoints and test for rejecting a session
#### What are the relevant pivotal tracker stories?
[Story Link](https://www.pivotaltracker.com/story/show/168131122)
